### PR TITLE
KMS key handing for Endpoint configuration

### DIFF
--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_basic_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_basic_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -219,7 +219,7 @@ class DeployEndpointStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
         # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
-            # create kms key to be used by the assets bucket
+
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_basic_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_basic_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -210,13 +210,21 @@ class DeployEndpointStack(Stack):
         endpoint_config_production_variant.load_for_stack(self)
 
         kms_key_id = None
-        # if the instance type is not having nvme ssd, then create a kms key to encrypt the assets bucket
+        # if the instance type is not having nvme ssd, then create a kms key to encrypt  data on instance storage
+        # volume if you provide kms key with instance type having nvme ssd then you will see below warning message
+        # warnings.warn(f"The provided kms key to use for encrypting the data on the endpoint's storage volume is
+        # ignored since the instance type {instance_type} has an instance store and the volume is encrypted using a
+        # hardware module on the instance.")
+        # For more details please see below link
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
+        # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
             # create kms key to be used by the assets bucket
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",
-                description="key used for encryption of data in Amazpn SageMaker Endpoint",
+                description="key used for encryption of data of storage volume attached to Amazon SageMaker Endpoint",
+                alias=f"{model_name}-sagemaker-endpoint-volume-key",
                 enable_key_rotation=True,
                 policy=iam.PolicyDocument(
                     statements=[

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_byoc_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_byoc_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -219,7 +219,7 @@ class DeployEndpointStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
         # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
-            # create kms key to be used by the assets bucket
+
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_byoc_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_byoc_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -210,13 +210,21 @@ class DeployEndpointStack(Stack):
         endpoint_config_production_variant.load_for_stack(self)
 
         kms_key_id = None
-        # if the instance type is not having nvme ssd, then create a kms key to encrypt the assets bucket
+        # if the instance type is not having nvme ssd, then create a kms key to encrypt  data on instance storage
+        # volume if you provide kms key with instance type having nvme ssd then you will see below warning message
+        # warnings.warn(f"The provided kms key to use for encrypting the data on the endpoint's storage volume is
+        # ignored since the instance type {instance_type} has an instance store and the volume is encrypted using a
+        # hardware module on the instance.")
+        # For more details please see below link
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
+        # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
             # create kms key to be used by the assets bucket
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",
-                description="key used for encryption of data in Amazpn SageMaker Endpoint",
+                description="key used for encryption of data of storage volume attached to Amazon SageMaker Endpoint",
+                alias=f"{model_name}-sagemaker-endpoint-volume-key",
                 enable_key_rotation=True,
                 policy=iam.PolicyDocument(
                     statements=[

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/config/cfn_nag_ignore.yml
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/config/cfn_nag_ignore.yml
@@ -1,0 +1,3 @@
+RulesToSuppress:
+  - id: "W1200"
+    reason: "W1200 is an warning raised due to using ec2 instance with nvme ssd"

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -219,7 +219,7 @@ class DeployEndpointStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
         # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
-            # create kms key to be used by the assets bucket
+
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/train_deploy_genai_cv_product/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -210,13 +210,21 @@ class DeployEndpointStack(Stack):
         endpoint_config_production_variant.load_for_stack(self)
 
         kms_key_id = None
-        # if the instance type is not having nvme ssd, then create a kms key to encrypt the assets bucket
+        # if the instance type is not having nvme ssd, then create a kms key to encrypt  data on instance storage
+        # volume if you provide kms key with instance type having nvme ssd then you will see below warning message
+        # warnings.warn(f"The provided kms key to use for encrypting the data on the endpoint's storage volume is
+        # ignored since the instance type {instance_type} has an instance store and the volume is encrypted using a
+        # hardware module on the instance.")
+        # For more details please see below link
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sagemaker/CfnEndpointConfig.html#aws_cdk
+        # .aws_sagemaker.CfnEndpointConfig
         if 'd' not in endpoint_config_production_variant.instance_type:
             # create kms key to be used by the assets bucket
             kms_key = kms.Key(
                 self,
                 "endpoint-kms-key",
-                description="key used for encryption of data in Amazpn SageMaker Endpoint",
+                description="key used for encryption of data of storage volume attached to Amazon SageMaker Endpoint",
+                alias=f"{model_name}-sagemaker-endpoint-volume-key",
                 enable_key_rotation=True,
                 policy=iam.PolicyDocument(
                     statements=[


### PR DESCRIPTION
for endpoint config, kms key not required for instance type which has instance storage of nvme ssd


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
